### PR TITLE
Update src.rego

### DIFF
--- a/policy/ocp/bestpractices/container-image-latest/src.rego
+++ b/policy/ocp/bestpractices/container-image-latest/src.rego
@@ -12,7 +12,13 @@ violation[msg] {
   openshift.is_policy_active("RHCOP-OCP_BESTPRACT-00003")
   container := openshift.containers[_]
 
-  endswith(container.image, ":latest")
+  has_latest_tag(container)
 
   msg := konstraint_core.format_with_id(sprintf("%s/%s: container '%s' is using the latest tag for its image (%s), which is an anti-pattern.", [konstraint_core.kind, konstraint_core.name, container.name, container.image]), "RHCOP-OCP_BESTPRACT-00003")
+}
+has_latest_tag(c) {
+  endswith(c.image, ":latest")
+}
+has_latest_tag(c) {
+  contains(c.image, ":") == false
 }


### PR DESCRIPTION
Current policy was allowing  an image to be created without a tag.  In order to prevent latest tag  completely, we can search for images without a tag.

#### What is this PR About?
Describe the contents of the PR

#### Check list
- [ ] Have you created a test case in `_test/conftest-unittests.sh`
- [ ] Have you created a test case in `_test/opa-profile.sh`
- [ ] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [ ] Have you created a test case in `_test/gatekeeper-k8s-integrationtests.sh`
- [ ] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [ ] Have you re-generated `POLICIES.md`

cc: @redhat-cop/rego-policies
